### PR TITLE
weak reference holding in index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,11 @@ dev:
 
 test:
 	cargo test
+
+pyenv:
+	python3 -m venv venv
+	source venv/bin/activate
+	pip install -r requirements.txt
+
+format:
+	cargo fmt


### PR DESCRIPTION
not sure if this is a better approach

converted "unsafe" code

however, previous usage of unsafe just made it so that the index embedded with a table could reference back up to the table, so it wasn't a big concern.

but i did write a bunch of tests, ensuring that the references was still being cleaned properly if the table is dropped